### PR TITLE
Usage of .env file instead of storing username and password in the application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .idea
 dist
 build
+.env

--- a/badgrclient/.sample.env
+++ b/badgrclient/.sample.env
@@ -1,0 +1,2 @@
+USERNAME = ""
+PASSWORD = ""

--- a/badgrclient/badgrclient.py
+++ b/badgrclient/badgrclient.py
@@ -34,8 +34,8 @@ Logger = logging.getLogger("badgrclient")
 class BadgrClient:
     def __init__(
         self,
-        username: str = getenv('USERNAME'),
-        password: str = getenv('PASSWORD'),
+        username: str = None,
+        password: str = None,
         client_id: str = None,
         scope: str = "rw:profile rw:issuer rw:backpack",
         base_url: str = "http://localhost:8000",
@@ -46,8 +46,8 @@ class BadgrClient:
         """Initalize a new client
 
         Args:
-            username: Badgr username(or email). Defaults to USERNAME from .env file.
-            password: Badgr password. Defaults to PASSWORD from .env file.
+            username: Badgr username(or email). Defaults to None.
+            password: Badgr password. Defaults to None.
             client_id: client_id to use to connect to badgr. Defaults to None.
             scope: OAuth Scope. Defaults to None.
             base_url: badgr-server's url. Defaults to 'http://localhost:8000'.
@@ -145,13 +145,15 @@ class BadgrClient:
 
         return response
 
-    def _get_auth_token(self, username=None, password=None):
+    def _get_auth_token(self, username=getenv('USERNAME'), password=getenv('PASSWORD')):
         """Fetches token and sets header for api calls. Uses refresh_token
         if username and password isn't provided
 
         Args:
             username (string): Badgr username
             password (string): Badgr password
+        Note:
+            By-default reads .env file for USERNAME and PASSWORD
         """
         now = datetime.datetime.now()
 

--- a/badgrclient/badgrclient.py
+++ b/badgrclient/badgrclient.py
@@ -10,6 +10,13 @@ from .badgrmodels import (
 from typing import List, Union
 from .exceptions import APIError, BadgrClientError
 
+from os.path import join, dirname
+from dotenv import load_dotenv
+from os import getenv
+
+dotenv_path = join(dirname(__file__), '.env')
+load_dotenv(dotenv_path)
+
 MODELS = {
     "Assertion": Assertion,
     "BadgeClass": BadgeClass,
@@ -27,8 +34,8 @@ Logger = logging.getLogger("badgrclient")
 class BadgrClient:
     def __init__(
         self,
-        username: str = None,
-        password: str = None,
+        username: str = getenv('USERNAME'),
+        password: str = getenv('PASSWORD'),
         client_id: str = None,
         scope: str = "rw:profile rw:issuer rw:backpack",
         base_url: str = "http://localhost:8000",
@@ -39,8 +46,8 @@ class BadgrClient:
         """Initalize a new client
 
         Args:
-            username: Badgr username(or email). Defaults to None.
-            password: Badgr password. Defaults to None.
+            username: Badgr username(or email). Defaults to USERNAME from .env file.
+            password: Badgr password. Defaults to PASSWORD from .env file.
             client_id: client_id to use to connect to badgr. Defaults to None.
             scope: OAuth Scope. Defaults to None.
             base_url: badgr-server's url. Defaults to 'http://localhost:8000'.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+python-dotenv==0.14.0


### PR DESCRIPTION
We'll be using an `.env` file instead of storing usernames and password in the application itself.

Changes Include:

- Addition of `.env` file in `.gitignore`
- Creation of a `.sample.env` file
- Addition of `python-dotenv==0.14.0` in `requirements.txt`
- BadgrClient now defaults to the data from `.env` file instead of None.

fixes: https://github.com/snehalbaghel/badgrclient/issues/1